### PR TITLE
convert attachment.content to text correctly

### DIFF
--- a/lib/Service/IndexMappingService.php
+++ b/lib/Service/IndexMappingService.php
@@ -302,9 +302,10 @@ class IndexMappingService {
 						'field'         => 'content',
 						'indexed_chars' => -1
 					],
-					'set'        => [
-						'field' => 'content',
-						'value' => '{{ attachment.content }}'
+					'convert'    => [
+						'field'        => 'attachment.content',
+						'type'         => 'string',
+						'target_field' => 'content'
 					],
 					'remove'     => [
 						'field'          => 'attachment.content',


### PR DESCRIPTION
Fixed to search correctly

`set` processor escaped control characters(ie. CR/LF).
Therefore, first word of a new line are not indexed.