### PR TITLE
ignore missing attachment.content filed

### DIFF
--- a/lib/Service/IndexMappingService.php
+++ b/lib/Service/IndexMappingService.php
@@ -303,9 +303,10 @@ class IndexMappingService {
 						'indexed_chars' => -1
 					],
 					'convert'    => [
-						'field'        => 'attachment.content',
-						'type'         => 'string',
-						'target_field' => 'content'
+						'field'          => 'attachment.content',
+						'type'           => 'string',
+						'target_field'   => 'content',
+						'ignore_missing' => true
 					],
 					'remove'     => [
 						'field'          => 'attachment.content',


### PR DESCRIPTION
Fix #31 exception occurred in `attachment` pipeline if add `Thumbs.db` to index.