### PR TITLE
Correctly format request to elasticsearch

### DIFF
--- a/lib/Service/IndexMappingService.php
+++ b/lib/Service/IndexMappingService.php
@@ -162,7 +162,7 @@ class IndexMappingService {
 			'groups'   => $access->getGroups(),
 			'circles'  => $access->getCircles(),
 			'metatags' => $document->getMetaTags(),
-			'subtags'  => $document->getSubTags(),
+			'subtags'  => $document->getSubTags(true),
 			'tags'     => $document->getTags(),
 			'hash'     => $document->getHash(),
 			'provider' => $document->getProviderId(),


### PR DESCRIPTION
Without this patch elasticsearch returns 400 bad request when indexing if subtags are set.