### PR TITLE
Ability to define analyzer (and not tokenizers) in the parameter of the fulltext search.

### DIFF
--- a/lib/Service/IndexMappingService.php
+++ b/lib/Service/IndexMappingService.php
@@ -262,7 +262,7 @@ class IndexMappingService {
 						],
 						'content'  => [
 							'type'        => 'text',
-							'analyzer'    => ConfigService::ANALYZER_TOKENIZER,
+							'analyzer'    => $this->configService->getAppValue(ConfigService::ANALYZER_TOKENIZER),
 							'term_vector' => 'yes',
 							'copy_to'     => 'combined'
 						],
@@ -286,7 +286,7 @@ class IndexMappingService {
 						],
 						'combined' => [
 							'type'        => 'text',
-							'analyzer'    => ConfigService::ANALYZER_TOKENIZER,
+							'analyzer'    => $this->configService->getAppValue(ConfigService::ANALYZER_TOKENIZER),
 							'term_vector' => 'yes'
 						]
 						//						,

--- a/lib/Service/IndexMappingService.php
+++ b/lib/Service/IndexMappingService.php
@@ -232,15 +232,6 @@ class IndexMappingService {
 							'pattern'     => '\\b((?i:never|no|nothing|nowhere|noone|none|not|havent|hasnt|hadnt|cant|couldnt|shouldnt|wont|wouldnt|dont|doesnt|didnt|isnt|arent|aint))\\s+(\\w+)',
 							'replacement' => '$1 ~$2'
 						]
-					],
-					'analyzer'    => [
-						'analyzer' => [
-							'type'      => 'custom',
-							'tokenizer' => $this->configService->getAppValue(
-								ConfigService::ANALYZER_TOKENIZER
-							),
-							'filter'    => ['lowercase', 'stop', 'kstem']
-						]
 					]
 				]
 			],
@@ -271,7 +262,7 @@ class IndexMappingService {
 						],
 						'content'  => [
 							'type'        => 'text',
-							'analyzer'    => 'analyzer',
+							'analyzer'    => ConfigService::ANALYZER_TOKENIZER,
 							'term_vector' => 'yes',
 							'copy_to'     => 'combined'
 						],
@@ -295,7 +286,7 @@ class IndexMappingService {
 						],
 						'combined' => [
 							'type'        => 'text',
-							'analyzer'    => 'analyzer',
+							'analyzer'    => ConfigService::ANALYZER_TOKENIZER,
 							'term_vector' => 'yes'
 						]
 						//						,


### PR DESCRIPTION
Elasticsearch is providing a lot of analyzers already ready for a lot of languages (italian, french,...) and we can easily define more analyzers in elasticsearch if we want to.

https://www.elastic.co/guide/en/elasticsearch/reference/6.2/analysis-lang-analyzer.html

But in the parameters of the fulltextSearch, we can only change the tokenizer and not the analyzer.

An analyzer (called "analyzer" in the code) is defined in the file lib/Service/IndexMappingService.php, in the method generateGlobalMap. This analyzer is used to analyze the content and the combined fields. 

I believe it would be better to let the user define the analyzer (and not the tokenizer) in the parameters, and then use this user provided analyzer name for the analyze of the documents contents.

Warning : 

* it introduces a BC Break for people that would use a custom tokenizer
* I don't manage to make my code work on my development nextcloud... (so I can't to a real dev for the moment...)

So this PR is not a real PR. It is a kind of issue with a code example to make my issue clear...

Best regards,
Philippe