### PR TITLE
set fields limit

### DIFF
--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -45,6 +45,7 @@ use OCP\PreConditionNotMetException;
 class ConfigService {
 
 
+	const FIELDS_LIMIT = 'fields_limit';
 	const ELASTIC_HOST = 'elastic_host';
 	const ELASTIC_INDEX = 'elastic_index';
 	const ANALYZER_TOKENIZER = 'analyzer_tokenizer';
@@ -53,6 +54,7 @@ class ConfigService {
 	public $defaults = [
 		self::ELASTIC_HOST       => '',
 		self::ELASTIC_INDEX      => '',
+		self::FIELDS_LIMIT       => '10000',
 		self::ANALYZER_TOKENIZER => 'standard'
 	];
 

--- a/lib/Service/IndexMappingService.php
+++ b/lib/Service/IndexMappingService.php
@@ -216,7 +216,8 @@ class IndexMappingService {
 		$params['include_type_name'] = true;
 		$params['body'] = [
 			'settings' => [
-				'analysis' => [
+				'index.mapping.total_fields.limit' => $this->configService->getAppValue(ConfigService::FIELDS_LIMIT),
+				'analysis'                         => [
 					'filter'      => [
 						'shingle' => [
 							'type' => 'shingle'


### PR DESCRIPTION
fix nextcloud/fulltextsearch#279

`./occ config:app:set fulltextsearch_elasticsearch fields_limit --value '10000'`