### PR TITLE
Move to positions_offsets iot fix 10k highlight limit

### DIFF
--- a/lib/Service/IndexMappingService.php
+++ b/lib/Service/IndexMappingService.php
@@ -261,7 +261,7 @@ class IndexMappingService {
 						'title'    => [
 							'type'        => 'text',
 							'analyzer'    => 'keyword',
-							'term_vector' => 'yes',
+							'term_vector' => 'with_positions_offsets',
 							'copy_to'     => 'combined'
 						],
 						'provider' => [
@@ -279,7 +279,7 @@ class IndexMappingService {
 						'content'  => [
 							'type'        => 'text',
 							'analyzer'    => 'analyzer',
-							'term_vector' => 'yes',
+							'term_vector' => 'with_positions_offsets',
 							'copy_to'     => 'combined'
 						],
 						'owner'    => [
@@ -303,7 +303,7 @@ class IndexMappingService {
 						'combined' => [
 							'type'        => 'text',
 							'analyzer'    => 'analyzer',
-							'term_vector' => 'yes'
+							'term_vector' => 'with_positions_offsets'
 						]
 						//						,
 						//						'topics'   => [


### PR DESCRIPTION
With the upgrade to ES 7 there are changes to avoid default limits on higliht with ES structural apps matching strings longer than 10k characters more here: https://github.com/elastic/kibana/issues/16764#issuecomment-367512904