### PR TITLE
Add a setting that allows to choose document type

### DIFF
--- a/js/admin.elements.js
+++ b/js/admin.elements.js
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *  
+ *
  */
 
 /** global: OCA */
@@ -32,6 +32,7 @@ var elasticsearch_elements = {
 	elasticsearch_div: null,
 	elasticsearch_host: null,
 	elasticsearch_index: null,
+	elasticsearch_type: null,
 	analyzer_tokenizer: null,
 
 
@@ -39,6 +40,7 @@ var elasticsearch_elements = {
 		elasticsearch_elements.elasticsearch_div = $('#elastic_search');
 		elasticsearch_elements.elasticsearch_host = $('#elasticsearch_host');
 		elasticsearch_elements.elasticsearch_index = $('#elasticsearch_index');
+		elasticsearch_elements.elasticsearch_type = $('#elasticsearch_type');
 		elasticsearch_elements.analyzer_tokenizer = $('#analyzer_tokenizer');
 
 		elasticsearch_elements.elasticsearch_host.on('input', function () {
@@ -53,6 +55,12 @@ var elasticsearch_elements = {
 			elasticsearch_settings.saveSettings();
 		});
 
+		elasticsearch_elements.elasticsearch_type.on('input', function () {
+			fts_admin_settings.tagSettingsAsNotSaved($(this));
+		}).blur(function () {
+			elasticsearch_settings.saveSettings();
+		});
+
 		elasticsearch_elements.analyzer_tokenizer.on('input', function () {
 			fts_admin_settings.tagSettingsAsNotSaved($(this));
 		}).blur(function () {
@@ -62,5 +70,3 @@ var elasticsearch_elements = {
 
 
 };
-
-

--- a/js/admin.settings.js
+++ b/js/admin.settings.js
@@ -47,10 +47,12 @@ var elasticsearch_settings = {
 
 	/** @namespace result.elastic_host */
 	/** @namespace result.elastic_index */
+	/** @namespace result.elastic_type */
 	updateSettingPage: function (result) {
 
 		elasticsearch_elements.elasticsearch_host.val(result.elastic_host);
 		elasticsearch_elements.elasticsearch_index.val(result.elastic_index);
+		elasticsearch_elements.elasticsearch_type.val(result.elastic_type);
 		elasticsearch_elements.analyzer_tokenizer.val(result.analyzer_tokenizer);
 
 		fts_admin_settings.tagSettingsAsSaved(elasticsearch_elements.elasticsearch_div);
@@ -62,6 +64,7 @@ var elasticsearch_settings = {
 		var data = {
 			elastic_host: elasticsearch_elements.elasticsearch_host.val(),
 			elastic_index: elasticsearch_elements.elasticsearch_index.val(),
+			elastic_type: elasticsearch_elements.elasticsearch_type.val(),
 			analyzer_tokenizer: elasticsearch_elements.analyzer_tokenizer.val()
 		};
 

--- a/l10n/fr.js
+++ b/l10n/fr.js
@@ -9,6 +9,8 @@ OC.L10N.register(
     "Include your credential in case authentication is required." : "Entrez vos informations d'identification si une authentification est demandée",
     "Index" : "Index",
     "Name of your index." : "Nom de votre index.",
+    "Type" : "Type",
+    "Name of your type. Please considere using _doc as type will no longer be supported.": "Nom du type. Les types ne seront plus supportés, il est préférable d'utiliser _doc."
     "[Advanced] Analyzer tokenizer" : "[Avancé] Analyseur de générateur de token",
     "Some language might needs a specific tokenizer." : "Certaines langues peuvent avoir besoin d'un jeton spécifique."
 },

--- a/l10n/fr.json
+++ b/l10n/fr.json
@@ -7,6 +7,8 @@
     "Include your credential in case authentication is required." : "Entrez vos informations d'identification si une authentification est demandée",
     "Index" : "Index",
     "Name of your index." : "Nom de votre index.",
+    "Type" : "Type",
+    "Name of your type. Please considere using _doc as type will no longer be supported.": "Nom du type. Les types ne seront plus supportés, il est préférable d'utiliser _doc.",
     "[Advanced] Analyzer tokenizer" : "[Avancé] Analyseur de générateur de token",
     "Some language might needs a specific tokenizer." : "Certaines langues peuvent avoir besoin d'un jeton spécifique."
 },"pluralForm" :"nplurals=2; plural=(n > 1);"

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -49,6 +49,7 @@ class ConfigService {
 	const FIELDS_LIMIT = 'fields_limit';
 	const ELASTIC_HOST = 'elastic_host';
 	const ELASTIC_INDEX = 'elastic_index';
+	const ELASTIC_TYPE = 'elastic_type';
 	const ELASTIC_VER_BELOW66 = 'es_ver_below66';
 	const ANALYZER_TOKENIZER = 'analyzer_tokenizer';
 
@@ -56,6 +57,7 @@ class ConfigService {
 	public $defaults = [
 		self::ELASTIC_HOST        => '',
 		self::ELASTIC_INDEX       => '',
+		self::ELASTIC_TYPE        => 'standard',
 		self::FIELDS_LIMIT        => '10000',
 		self::ELASTIC_VER_BELOW66 => '0',
 		self::ANALYZER_TOKENIZER  => 'standard'
@@ -147,6 +149,25 @@ class ConfigService {
 		}
 
 		return $index;
+	}
+
+	/**
+	 * Return elasticsearch type document. If no type is configured, it
+	 * defaults to 'standard' for backward compatibility
+	 *
+	 * @return string
+	 * @throws ConfigurationException
+	 */
+	public function getElasticType(): string {
+
+		$type = $this->getAppValue(self::ELASTIC_TYPE);
+		if ($type === '') {
+			throw new ConfigurationException(
+				'Your ElasticSearchPlatform is not configured properly'
+			);
+		}
+
+		return $type;
 	}
 
 
@@ -253,4 +274,3 @@ class ConfigService {
 	}
 
 }
-

--- a/lib/Service/IndexMappingService.php
+++ b/lib/Service/IndexMappingService.php
@@ -79,7 +79,7 @@ class IndexMappingService {
 				[
 					'index' => $this->configService->getElasticIndex(),
 					'id'    => $document->getProviderId() . ':' . $document->getId(),
-					'type'  => 'standard',
+					'type'  => $this->configService->getElasticType(),
 					'body'  => $this->generateIndexBody($document)
 				]
 		];
@@ -104,7 +104,7 @@ class IndexMappingService {
 				[
 					'index' => $this->configService->getElasticIndex(),
 					'id'    => $document->getProviderId() . ':' . $document->getId(),
-					'type'  => 'standard',
+					'type'  => $this->configService->getElasticType(),
 					'body'  => ['doc' => $this->generateIndexBody($document)]
 				]
 		];
@@ -131,7 +131,7 @@ class IndexMappingService {
 				[
 					'index' => $this->configService->getElasticIndex(),
 					'id'    => $providerId . ':' . $documentId,
-					'type'  => 'standard'
+					'type'  => $this->configService->getElasticType()
 				]
 		];
 
@@ -252,7 +252,7 @@ class IndexMappingService {
 				]
 			],
 			'mappings' => [
-				'standard' => [
+				$this->configService->getElasticType() => [
 					'dynamic'    => true,
 					'properties' => [
 						'source'   => [
@@ -370,7 +370,7 @@ class IndexMappingService {
 	public function generateDeleteQuery(string $providerId): array {
 		$params = [
 			'index' => $this->configService->getElasticIndex(),
-			'type'  => 'standard'
+			'type'  => $this->configService->getElasticType()
 		];
 
 		$params['body']['query']['match'] = ['provider' => $providerId];
@@ -379,4 +379,3 @@ class IndexMappingService {
 	}
 
 }
-

--- a/lib/Service/SearchMappingService.php
+++ b/lib/Service/SearchMappingService.php
@@ -99,7 +99,7 @@ class SearchMappingService {
 	): array {
 		$params = [
 			'index' => $this->configService->getElasticIndex(),
-			'type'  => 'standard',
+			'type'  => $this->configService->getElasticType(),
 			'size'  => $request->getSize(),
 			'from'  => (($request->getPage() - 1) * $request->getSize())
 		];
@@ -455,7 +455,7 @@ class SearchMappingService {
 	public function getDocumentQuery(string $providerId, string $documentId): array {
 		return [
 			'index' => $this->configService->getElasticIndex(),
-			'type'  => 'standard',
+			'type'  => $this->configService->getElasticType(),
 			'id'    => $providerId . ':' . $documentId
 		];
 	}
@@ -475,4 +475,3 @@ class SearchMappingService {
 	}
 
 }
-

--- a/templates/settings.admin.php
+++ b/templates/settings.admin.php
@@ -71,6 +71,17 @@ Util::addStyle(Application::APP_NAME, 'admin');
 
 		<div class="div-table-row">
 			<div class="div-table-col div-table-col-left">
+				<span class="leftcol"><?php p($l->t('Type')); ?>:</span>
+				<br/>
+				<em><?php p($l->t('Name of your type. Please considere using _doc as type will no longer be supported.')); ?></em>
+			</div>
+			<div class="div-table-col">
+				<input type="text" id="elasticsearch_type" placeholder="my_type"/>
+			</div>
+		</div>
+
+		<div class="div-table-row">
+			<div class="div-table-col div-table-col-left">
 				<span class="leftcol"><?php p($l->t('[Advanced] Analyzer tokenizer')); ?>:</span>
 				<br/>
 				<em><?php p($l->t('Some language might needs a specific tokenizer.')); ?></em>


### PR DESCRIPTION
Due to type removal in elasticsearch, new indices needs to have _doc as document type at least for elastic 7.8.1. This pull request add a setting that allows to choose document type.   
I tried to keep backward compatibility using `standard` as default.  
This is a short term fix as type will be completely removed in elastic 8.

Tested with `fulltextsearch:test` against a NC19 with elasticsearch fulltext search configured with `_doc` as type and an elasticsearch 7.8.1 node.

```
./occ fulltextsearch:test

.Testing your current setup:
Creating mocked content provider. ok
Testing mocked provider: get indexable documents. (2 items) ok
Loading search platform. (Elasticsearch) ok
Testing search platform. ok
Locking process ok
Removing test. ok
Pausing 3 seconds 1 2 3 ok
Initializing index mapping. ok
Indexing generated documents. ok
Pausing 3 seconds 1 2 3 ok
Retreiving content from a big index (license). (size: 32386) ok
Comparing document with source. ok
Searching basic keywords:
 - 'test' (result: 1, expected: ["simple"]) ok
 - 'document is a simple test' (result: 2, expected: ["simple","license"]) ok
 - '"document is a test"' (result: 0, expected: []) ok
 - '"document is a simple test"' (result: 1, expected: ["simple"]) ok
 - 'document is a simple -test' (result: 1, expected: ["license"]) ok
 - 'document is a simple +test' (result: 1, expected: ["simple"]) ok
 - '-document is a simple test' (result: 0, expected: []) ok
 - 'document is a simple +test +testing' (result: 1, expected: ["simple"]) ok
 - 'document is a simple +test -testing' (result: 0, expected: []) ok
 - 'document is a +simple -test -testing' (result: 0, expected: []) ok
 - '+document is a simple -test -testing' (result: 1, expected: ["license"]) ok
 - 'document is a +simple -license +testing' (result: 1, expected: ["simple"]) ok
Updating documents access. ok
Pausing 3 seconds 1 2 3 ok
Searching with group access rights:
 - 'license' - [] -  (result: 0, expected: []) ok
 - 'license' - ["group_1"] -  (result: 1, expected: ["license"]) ok
 - 'license' - ["group_1","group_2"] -  (result: 1, expected: ["license"]) ok
 - 'license' - ["group_3","group_2"] -  (result: 1, expected: ["license"]) ok
 - 'license' - ["group_3"] -  (result: 0, expected: []) ok
Searching with share rights:
 - 'license' - notuser -  (result: 0, expected: []) ok
 - 'license' - user2 -  (result: 1, expected: ["license"]) ok
 - 'license' - user3 -  (result: 1, expected: ["license"]) ok
Removing test. ok
Unlocking process ok
```

Closes #115 