### PR TITLE
Exclude unused content field for better search performance

### DIFF
--- a/lib/Service/SearchMappingService.php
+++ b/lib/Service/SearchMappingService.php
@@ -100,7 +100,8 @@ class SearchMappingService {
 		$params = [
 			'index' => $this->configService->getElasticIndex(),
 			'size'  => $request->getSize(),
-			'from'  => (($request->getPage() - 1) * $request->getSize())
+			'from'  => (($request->getPage() - 1) * $request->getSize()),
+			'_source_excludes' => 'content'
 		];
 
 		$bool = [];


### PR DESCRIPTION
**Current situation**
If a search request is executed against the ElasticSearch index, for each search result the whole document is returned including the `content` field, where the content of the file is stored. Depending on the infrastructure this leads to an unnecessary network traffic overhead since the content of the `content` field has to be transferred to the Nextcloud backend every time. This can lead to performance issues especially when dealing with bigger files.

**Proposal**
Since the `content` field is not used in the response at all this can be stipped out of the search result provided by ES.

**Compatibility**
The `_source_excludes` GET parameter was introduced in ElasticSearch 6.8 (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.6.html#_deprecate_literal__source_exclude_literal_and_literal__source_include_literal_url_parameters)) and is still supported in the current version 7.15 (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.15/docs-get.html)). Also the currently used PHP ElasticSearch has official support for this field (see [here](https://github.com/elastic/elasticsearch-php/blob/25522ef4f16adcf49d7a1db149f2fcf010655b7f/src/Elasticsearch/Client.php#L1202)).