### PR TITLE
simple solution to fix indexing of .ods files

### DIFF
--- a/lib/Service/IndexMappingService.php
+++ b/lib/Service/IndexMappingService.php
@@ -344,7 +344,8 @@ class IndexMappingService {
 					'convert'    => [
 						'field'        => 'attachment.content',
 						'type'         => 'string',
-						'target_field' => 'content'
+						'target_field' => 'content',
+						'ignore_failure' => true
 					],
 					'remove'     => [
 						'field'          => 'attachment.content',


### PR DESCRIPTION
Signed-off-by: Hervé KIENLEN <hkienlen@arawa.fr>

# BUG

new .ods documents are not indexed live

field [content] not present as part of path [attachment.content]


# Resolution

It seems there is no field attachment.content for .ods document.So ignoring the error from the attachement ingest solves the issue


```
attachment
Description
attachment
Processors
[
  {
    "attachment": {
      "field": "content",
      "indexed_chars": -1
    },
    "convert": {
      "field": "attachment.content",
      "type": "string",
      "target_field": "content",
      "ignore_failure": true
    },
    "remove": {
      "field": "attachment.content",
      "ignore_failure": true
    }
  }
```