### PR TITLE
fix status array on error

### DIFF
--- a/lib/Platform/ElasticSearchPlatform.php
+++ b/lib/Platform/ElasticSearchPlatform.php
@@ -313,11 +313,11 @@ class ElasticSearchPlatform implements IFullTextSearchPlatform {
 	private function parseIndexErrorException(Exception $e): array {
 		$arr = json_decode($e->getMessage(), true);
 		if (!is_array($arr)) {
-			return ['error', 'unknown error'];
+			return ['error', 'unknown error', ''];
 		}
 
 		if (empty($this->getArray('error', $arr))) {
-			return ['error', $e->getMessage()];
+			return ['error', $e->getMessage(), ''];
 		}
 
 		try {
@@ -330,7 +330,7 @@ class ElasticSearchPlatform implements IFullTextSearchPlatform {
 			return ['error', $this->get('reason', $cause[0]), $this->get('type', $cause[0])];
 		}
 
-		return ['error', $e->getMessage()];
+		return ['error', $e->getMessage(), ''];
 	}
 
 	/**


### PR DESCRIPTION
it seems that PHP8 does not allow missing entry in returned array when running this code:

```
[$var1, $var2, $var3] = [$var1 => 1, $var2 => 2];
```

This PR fix the missing entry