### PR TITLE
User and owner filters

### DIFF
--- a/lib/Service/SearchMappingService.php
+++ b/lib/Service/SearchMappingService.php
@@ -311,11 +311,11 @@ class SearchMappingService {
 		$query[] = ['term' => ['users.keyword' => '__all']];
 
 		foreach ($access->getGroups() as $group) {
-			$query[] = ['term' => ['groups' => strtolower($group)]];
+			$query[] = ['term' => ['groups.keyword' => $group]];
 		}
 
 		foreach ($access->getCircles() as $circle) {
-			$query[] = ['term' => ['circles' => strtolower($circle)]];
+			$query[] = ['term' => ['circles.keyword' => $circle]];
 		}
 
 		return $query;

--- a/lib/Service/SearchMappingService.php
+++ b/lib/Service/SearchMappingService.php
@@ -306,9 +306,9 @@ class SearchMappingService {
 	 */
 	private function generateSearchQueryAccess(IDocumentAccess $access): array {
 		$query = [];
-		$query[] = ['term' => ['owner' => $access->getViewerId()]];
-		$query[] = ['term' => ['users' => $access->getViewerId()]];
-		$query[] = ['term' => ['users' => '__all']];
+		$query[] = ['term' => ['owner.keyword' => $access->getViewerId()]];
+		$query[] = ['term' => ['users.keyword' => $access->getViewerId()]];
+		$query[] = ['term' => ['users.keyword' => '__all']];
 
 		foreach ($access->getGroups() as $group) {
 			$query[] = ['term' => ['groups' => strtolower($group)]];


### PR DESCRIPTION
The use of "keyword" will allow the search key to be exact, Elasticsearch will not perform any transformations. This use case will consider external user sources (LDAP), where the username may have dashes or symbols that could be misinterpreted by the engine.

Signed-off-by: Silvio <silvioq@gmail.com>