### PR TITLE
Be clear that ES7 is no longer supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,11 @@
 
 - compat nc27
 
-
 ### 26.0.0
 
+- BREAKING CHANGE: drop support for es7
 - compat nc26
 - compat es8
-
 
 ### 25.0.0
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It allows you to index your content into an Elasticsearch platform.
 
 ## Compatibility
 
-- This app is currently only compatible with Elasticsearch 7
+- As of version 26.0.0 this app is only compatible with Elasticsearch 8
 
 
 ### Documentation


### PR DESCRIPTION
The current docs are misleading. I broke my NC install because there was no indication that ES7 is no longer supported.

Hopefully this will protect another admin out there.

Source: https://github.com/nextcloud/fulltextsearch_elasticsearch/issues/269#issuecomment-1646837405