### PR TITLE
Create ES client with logger NC implementation

### DIFF
--- a/lib/Platform/ElasticSearchPlatform.php
+++ b/lib/Platform/ElasticSearchPlatform.php
@@ -48,7 +48,7 @@ use OCP\FullTextSearch\Model\IIndex;
 use OCP\FullTextSearch\Model\IIndexDocument;
 use OCP\FullTextSearch\Model\IRunner;
 use OCP\FullTextSearch\Model\ISearchResult;
-
+use Psr\Log\LoggerInterface;
 
 /**
  * Class ElasticSearchPlatform
@@ -67,6 +67,7 @@ class ElasticSearchPlatform implements IFullTextSearchPlatform {
 		private ConfigService $configService,
 		private IndexService $indexService,
 		private SearchService $searchService,
+		private LoggerInterface $logger,
 	) {
 	}
 
@@ -386,7 +387,8 @@ class ElasticSearchPlatform implements IFullTextSearchPlatform {
 		$hosts = array_map([$this, 'cleanHost'], $hosts);
 		$cb = ClientBuilder::create()
 			->setHosts($hosts)
-			->setRetries(3);
+			->setRetries(3)
+			->setLogger($this->logger);
 
 		$cb->setSSLVerification(!$this->configService->getAppValueBool(ConfigService::ALLOW_SELF_SIGNED_CERT));
 		$this->configureAuthentication($cb, $hosts);


### PR DESCRIPTION
Currently if there's a problem with a ES search query, we're not able to debug the query which is sent to the Elasticsearch server since we only see messages like "Searching ES" (without further info). Instead of trying to log the request on our owns, we should make use of the [built-in logging capability of the ES client](https://github.com/elastic/elastic-transport-php/blob/b1d761549cebddf2add49921ef67242897b635df/src/Transport.php#L233).

This will give us additional log messages like:

```json
{
  "reqId": "k740GWHGI1fs24c9nd88",
  "level": 0,
  "time": "2023-09-04T18:11:56+00:00",
  "remoteAddr": "172.19.0.1",
  "user": "admin",
  "app": "fulltextsearch_elasticsearch",
  "method": "GET",
  "url": "/index.php/apps/fulltextsearch/v1/search?request=%7B%22providers%22%3A%22all%22%2C%22options%22%3A%7B%7D%2C%22search%22%3A%22beleg%22%2C%22page%22%3A1%7D",
  "message": "Headers: {\"Host\":[\"elasticsearch_nc:9200\"],\"Accept\":[\"application\\/vnd.elasticsearch+json; compatible-with=8\"],\"Content-Type\":[\"application\\/vnd.elasticsearch+json; compatible-with=8\"],\"User-Agent\":[\"elasticsearch-php\\/8.8.2 (Linux 5.15.0-82-generic; PHP 8.1.2-1ubuntu2.13)\"],\"x-elastic-client-meta\":[\"es=8.8.2,php=8.1.2,t=8.7.0,a=0,gu=7.7.0\"]}\nBody: {\"query\":{\"bool\":{\"must\":{\"bool\":{\"should\":[{\"match_phrase_prefix\":{\"content\":\"beleg\"}},{\"match_phrase_prefix\":{\"title\":\"beleg\"}},{\"match_phrase_prefix\":{\"share_names.admin\":\"beleg\"}},{\"wildcard\":{\"title\":\"*beleg*\"}},{\"wildcard\":{\"share_names.admin\":\"*beleg*\"}},{\"query_string\":{\"fields\":[\"parts.comments\"],\"query\":\"beleg\"}}]}},\"filter\":[{\"bool\":{\"must\":{\"term\":{\"provider\":\"files\"}}}},{\"bool\":{\"should\":[{\"term\":{\"owner\":\"admin\"}},{\"term\":{\"users\":\"admin\"}},{\"term\":{\"users\":\"__all\"}},{\"term\":{\"groups\":\"admin\"}}]}},{\"bool\":{\"should\":[]}},{\"bool\":{\"must\":[]}},{\"bool\":{\"must\":[]}}]}},\"highlight\":{\"fields\":{\"content\":{},\"parts.comments\":{}},\"pre_tags\":[\"\"],\"post_tags\":[\"\"]}}",
  "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36",
  "version": "28.0.0.2",
  "data": {
    "app": "fulltextsearch_elasticsearch"
  },
  "id": "64f61e6b5d6b6"
}
```

This makes is possible to reconstruct the ES query and debug it for example via CURL.