### PR TITLE
prioritize system config

### DIFF
--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -142,7 +142,10 @@ class ConfigService {
 			$defaultValue = self::$defaults[$key];
 		}
 
-		return $this->config->getAppValue(Application::APP_NAME, $key, $defaultValue);
+		return $this->config->getSystemValueString(
+			Application::APP_NAME . '.' . $key,
+			$this->config->getAppValue(Application::APP_NAME, $key, $defaultValue)
+		);
 	}
 
 


### PR DESCRIPTION
allow the configuration of the app via `config.php`:

_(example)_
```
  'fulltextsearch_elasticsearch.elastic_host' => 'http://127.0.0.1:4321',
```