### PR TITLE
Update ConfigService.php

### DIFF
--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -56,7 +56,7 @@ class ConfigService {
 		self::ELASTIC_INDEX => '',
 		self::FIELDS_LIMIT => '10000',
 		self::ELASTIC_VER_BELOW66 => '0',
-		self::ELASTIC_LOGGER_ENABLED => true,
+		self::ELASTIC_LOGGER_ENABLED => 'true',
 		self::ANALYZER_TOKENIZER => 'standard',
 		self::ALLOW_SELF_SIGNED_CERT => 'false'
 	];


### PR DESCRIPTION
Solves error message:
OC\AllConfig::getSystemValueString(): Argument #2 ($default) must be of type string, bool given, called in /var/www/html/custom_apps/fulltextsearch_elasticsearch/lib/Service/ConfigService.php on line 147 and defined in /var/www/html/lib/private/AllConfig.php:163