### PR TITLE
migrate to 32+lexicon

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@ Extension to the _Full text search_ app to communicate with ElasticSearch.
 
 ]]>
 	</description>
-	<version>32.0.0-dev.0</version>
+	<version>32.0.0</version>
 	<licence>agpl</licence>
 	<author>Maxence Lange</author>
 	<namespace>FullTextSearch_Elasticsearch</namespace>
@@ -27,7 +27,7 @@ Extension to the _Full text search_ app to communicate with ElasticSearch.
 	<repository>https://github.com/nextcloud/fulltextsearch_elasticsearch.git</repository>
 	<screenshot>https://raw.githubusercontent.com/nextcloud/fulltextsearch/master/screenshots/0.3.0.png</screenshot>
 	<dependencies>
-		<nextcloud min-version="31" max-version="32"/>
+		<nextcloud min-version="32" max-version="33"/>
 	</dependencies>
 
 	<commands>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -6,36 +6,25 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 namespace OCA\FullTextSearch_Elasticsearch\AppInfo;
 
+use OCA\FullTextSearch_Elasticsearch\ConfigLexicon;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
 
 class Application extends App implements IBootstrap {
-
 	const APP_NAME = 'fulltextsearch_elasticsearch';
 
-	/**
-	 * Application constructor.
-	 *
-	 * @param array $params
-	 */
 	public function __construct(array $params = []) {
 		parent::__construct(self::APP_NAME, $params);
 	}
 
-	/**
-	 * @param IRegistrationContext $context
-	 */
 	public function register(IRegistrationContext $context): void {
+		$context->registerConfigLexicon(ConfigLexicon::class);
 	}
 
-	/**
-	 * @param IBootContext $context
-	 */
 	public function boot(IBootContext $context): void {
 	}
 }

--- a/lib/Command/Configure.php
+++ b/lib/Command/Configure.php
@@ -28,7 +28,7 @@ class Configure extends Base {
 	protected function configure() {
 		parent::configure();
 		$this->setName('fulltextsearch_elasticsearch:configure')
-			 ->addArgument('json', InputArgument::REQUIRED, 'set config')
+			 ->addArgument('json', InputArgument::OPTIONAL, 'set config')
 			 ->setDescription('Configure the installation');
 	}
 
@@ -40,26 +40,12 @@ class Configure extends Base {
 	 * @throws Exception
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		$json = $input->getArgument('json');
-
-		$config = json_decode($json, true);
-
-		if (!is_array($config)) {
-			$output->writeln('Invalid JSON');
-
-			return 1;
-		}
-
-		$ak = array_keys($config);
-		foreach ($ak as $k) {
-			if (array_key_exists($k, ConfigService::$defaults)) {
-				$this->configService->setAppValue($k, $config[$k]);
-			}
+		if ($input->getArgument('json')) {
+			$this->configService->setConfig(json_decode($input->getArgument('json') ?? '', true) ?? []);
 		}
 
 		$output->writeln(json_encode($this->configService->getConfig(), JSON_PRETTY_PRINT));
-
-		return 0;
+		return self::SUCCESS;
 	}
 }
 

--- a/lib/ConfigLexicon.php
+++ b/lib/ConfigLexicon.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\FullTextSearch_Elasticsearch;
+
+use OCP\Config\Lexicon\Entry;
+use OCP\Config\Lexicon\ILexicon;
+use OCP\Config\Lexicon\Strictness;
+use OCP\Config\ValueType;
+
+/**
+ * Config Lexicon for fulltextsearch_elasticsearch.
+ *
+ * Please Add & Manage your Config Keys in that file and keep the Lexicon up to date!
+ */
+class ConfigLexicon implements ILexicon {
+	public const FIELDS_LIMIT = 'fields_limit';
+	public const ELASTIC_HOST = 'elastic_host';
+	public const ELASTIC_INDEX = 'elastic_index';
+	public const ELASTIC_LOGGER_ENABLED = 'elastic_logger_enabled';
+	public const ANALYZER_TOKENIZER = 'analyzer_tokenizer';
+	public const ALLOW_SELF_SIGNED_CERT = 'allow_self_signed_cert';
+
+	public function getStrictness(): Strictness {
+		return Strictness::NOTICE;
+	}
+
+	public function getAppConfigs(): array {
+		return [
+			new Entry(key: self::FIELDS_LIMIT, type: ValueType::INT, defaultRaw: 10000, definition: 'Maximum number of fields in the index map', lazy: true),
+			new Entry(key: self::ELASTIC_HOST, type: ValueType::STRING, defaultRaw: '', definition: 'Address of the elasticsearch', lazy: true),
+			new Entry(key: self::ELASTIC_INDEX, type: ValueType::STRING, defaultRaw: '', definition: 'Name of the index on elasticsearch', lazy: true),
+			new Entry(key: self::ELASTIC_LOGGER_ENABLED, type: ValueType::BOOL, defaultRaw: false, definition: 'Allow 3rd-party elasticsearch-php to write in nextcloud.log', lazy: true, note: 'Be aware that if your nextcloud log level is set to DEBUG (0), clear version of the credentials used to the remote elasticsearch could end up in your logs'),
+			new Entry(key: self::ANALYZER_TOKENIZER, type: ValueType::STRING, defaultRaw: 'standard', definition: 'used analyzer tokenizer', lazy: true),
+			new Entry(key: self::ALLOW_SELF_SIGNED_CERT, type: ValueType::BOOL, defaultRaw: false, definition: 'allow self signed certificate', lazy: true),
+		];
+	}
+
+	public function getUserConfigs(): array {
+		return [];
+	}
+}

--- a/lib/Service/IndexMappingService.php
+++ b/lib/Service/IndexMappingService.php
@@ -9,12 +9,14 @@ declare(strict_types=1);
 
 namespace OCA\FullTextSearch_Elasticsearch\Service;
 
+use OCA\FullTextSearch_Elasticsearch\ConfigLexicon;
 use OCA\FullTextSearch_Elasticsearch\Vendor\Elastic\Elasticsearch\Client;
 use OCA\FullTextSearch_Elasticsearch\Vendor\Elastic\Elasticsearch\Exception\ClientResponseException;
 use OCA\FullTextSearch_Elasticsearch\Vendor\Elastic\Elasticsearch\Exception\MissingParameterException;
 use OCA\FullTextSearch_Elasticsearch\Vendor\Elastic\Elasticsearch\Exception\ServerResponseException;
 use OCA\FullTextSearch_Elasticsearch\Exceptions\AccessIsEmptyException;
 use OCA\FullTextSearch_Elasticsearch\Exceptions\ConfigurationException;
+use OCP\AppFramework\Services\IAppConfig;
 use OCP\FullTextSearch\Model\IIndexDocument;
 
 
@@ -26,7 +28,8 @@ use OCP\FullTextSearch\Model\IIndexDocument;
 class IndexMappingService {
 
 	public function __construct(
-		private ConfigService $configService
+		private ConfigService $configService,
+		private readonly IAppConfig $appConfig,
 	) {
 	}
 
@@ -185,9 +188,7 @@ class IndexMappingService {
 
 		$params['body'] = [
 			'settings' => [
-				'index.mapping.total_fields.limit' => $this->configService->getAppValue(
-					ConfigService::FIELDS_LIMIT
-				),
+				'index.mapping.total_fields.limit' => $this->appConfig->getAppValueInt(ConfigLexicon::FIELDS_LIMIT),
 				'analysis' => [
 					'filter' => [
 						'shingle' => [
@@ -209,9 +210,7 @@ class IndexMappingService {
 					'analyzer' => [
 						'analyzer' => [
 							'type' => 'custom',
-							'tokenizer' => $this->configService->getAppValue(
-								ConfigService::ANALYZER_TOKENIZER
-							),
+							'tokenizer' => $this->appConfig->getAppValueString(ConfigLexicon::ANALYZER_TOKENIZER),
 							'filter' => ['lowercase', 'stop', 'kstem']
 						]
 					]


### PR DESCRIPTION
- versioning
- implementation of Lexicon
- implementation of new `IAppConfig` api and keeping current Controller compatible,
- JSON is now optional when using `./occ files_fulltextsearch:configure`, meaning current configuration will be returned on no JSON
