### PR TITLE
Fix admin UI without global jQuery

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -27,7 +27,7 @@ Extension to the _Full text search_ app to communicate with ElasticSearch.
 	<repository>https://github.com/nextcloud/fulltextsearch_elasticsearch.git</repository>
 	<screenshot>https://raw.githubusercontent.com/nextcloud/fulltextsearch/master/screenshots/0.3.0.png</screenshot>
 	<dependencies>
-		<nextcloud min-version="32" max-version="33"/>
+		<nextcloud min-version="32" max-version="34"/>
 	</dependencies>
 
 	<commands>

--- a/js/admin.elements.js
+++ b/js/admin.elements.js
@@ -16,31 +16,24 @@ var elasticsearch_elements = {
 
 
 	init: function () {
-		elasticsearch_elements.elasticsearch_div = $('#elastic_search');
-		elasticsearch_elements.elasticsearch_host = $('#elasticsearch_host');
-		elasticsearch_elements.elasticsearch_index = $('#elasticsearch_index');
-		elasticsearch_elements.analyzer_tokenizer = $('#analyzer_tokenizer');
+		elasticsearch_elements.elasticsearch_div = document.getElementById('elastic_search');
+		elasticsearch_elements.elasticsearch_host = document.getElementById('elasticsearch_host');
+		elasticsearch_elements.elasticsearch_index = document.getElementById('elasticsearch_index');
+		elasticsearch_elements.analyzer_tokenizer = document.getElementById('analyzer_tokenizer');
 
-		elasticsearch_elements.elasticsearch_host.on('input', function () {
-			fts_admin_settings.tagSettingsAsNotSaved($(this));
-		}).blur(function () {
-			elasticsearch_settings.saveSettings();
+		elasticsearch_elements.bindInput(elasticsearch_elements.elasticsearch_host);
+		elasticsearch_elements.bindInput(elasticsearch_elements.elasticsearch_index);
+		elasticsearch_elements.bindInput(elasticsearch_elements.analyzer_tokenizer);
+	},
+
+
+	bindInput: function (element) {
+		element.addEventListener('input', function () {
+			fts_admin_settings.tagSettingsAsNotSaved(this);
 		});
-
-		elasticsearch_elements.elasticsearch_index.on('input', function () {
-			fts_admin_settings.tagSettingsAsNotSaved($(this));
-		}).blur(function () {
-			elasticsearch_settings.saveSettings();
-		});
-
-		elasticsearch_elements.analyzer_tokenizer.on('input', function () {
-			fts_admin_settings.tagSettingsAsNotSaved($(this));
-		}).blur(function () {
+		element.addEventListener('blur', function () {
 			elasticsearch_settings.saveSettings();
 		});
 	}
-
-
 };
-
 

--- a/js/admin.js
+++ b/js/admin.js
@@ -7,22 +7,31 @@
 /** global: elasticsearch_elements */
 /** global: elasticsearch_settings */
 
+function ready(callback) {
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', callback);
+	} else {
+		callback();
+	}
+}
 
-$(document).ready(function () {
+
+ready(function () {
 
 
 	/**
 	 * @constructs ElasticSearchAdmin
 	 */
 	var ElasticSearchAdmin = function () {
-		$.extend(ElasticSearchAdmin.prototype, elasticsearch_elements);
-		$.extend(ElasticSearchAdmin.prototype, elasticsearch_settings);
+		Object.assign(ElasticSearchAdmin.prototype, elasticsearch_elements, elasticsearch_settings);
 
 		elasticsearch_elements.init();
 		elasticsearch_settings.refreshSettingPage();
 	};
 
-	OCA.FullTextSearchAdmin.elasticSearch = ElasticSearchAdmin;
-	OCA.FullTextSearchAdmin.elasticSearch.settings = new ElasticSearchAdmin();
+	window.OCA = window.OCA || {};
+	window.OCA.FullTextSearchAdmin = window.OCA.FullTextSearchAdmin || {};
+	window.OCA.FullTextSearchAdmin.elasticSearch = ElasticSearchAdmin;
+	window.OCA.FullTextSearchAdmin.elasticSearch.settings = new ElasticSearchAdmin();
 
 });

--- a/js/admin.settings.js
+++ b/js/admin.settings.js
@@ -16,10 +16,7 @@ var elasticsearch_settings = {
 
 	refreshSettingPage: function () {
 
-		$.ajax({
-			method: 'GET',
-			url: OC.generateUrl('/apps/fulltextsearch_elasticsearch/admin/settings')
-		}).done(function (res) {
+		elasticsearch_settings.request('GET', '/apps/fulltextsearch_elasticsearch/admin/settings').then(function (res) {
 			elasticsearch_settings.updateSettingPage(res);
 		});
 
@@ -29,9 +26,9 @@ var elasticsearch_settings = {
 	/** @namespace result.elastic_index */
 	updateSettingPage: function (result) {
 
-		elasticsearch_elements.elasticsearch_host.val(result.elastic_host);
-		elasticsearch_elements.elasticsearch_index.val(result.elastic_index);
-		elasticsearch_elements.analyzer_tokenizer.val(result.analyzer_tokenizer);
+		elasticsearch_elements.elasticsearch_host.value = result.elastic_host;
+		elasticsearch_elements.elasticsearch_index.value = result.elastic_index;
+		elasticsearch_elements.analyzer_tokenizer.value = result.analyzer_tokenizer;
 
 		fts_admin_settings.tagSettingsAsSaved(elasticsearch_elements.elasticsearch_div);
 	},
@@ -40,21 +37,50 @@ var elasticsearch_settings = {
 	saveSettings: function () {
 
 		var data = {
-			elastic_host: elasticsearch_elements.elasticsearch_host.val(),
-			elastic_index: elasticsearch_elements.elasticsearch_index.val(),
-			analyzer_tokenizer: elasticsearch_elements.analyzer_tokenizer.val()
+			elastic_host: elasticsearch_elements.elasticsearch_host.value,
+			elastic_index: elasticsearch_elements.elasticsearch_index.value,
+			analyzer_tokenizer: elasticsearch_elements.analyzer_tokenizer.value
 		};
 
-		$.ajax({
-			method: 'POST',
-			url: OC.generateUrl('/apps/fulltextsearch_elasticsearch/admin/settings'),
-			data: {
-				data: data
-			}
-		}).done(function (res) {
+		elasticsearch_settings.request('POST', '/apps/fulltextsearch_elasticsearch/admin/settings', data).then(function (res) {
 			elasticsearch_settings.updateSettingPage(res);
 		});
 
+	},
+
+
+	request: function (method, route, data) {
+		var options = {
+			method: method,
+			credentials: 'same-origin',
+			headers: {
+				'Accept': 'application/json',
+				'requesttoken': window.OC ? window.OC.requestToken : ''
+			}
+		};
+
+		if (method === 'POST') {
+			options.headers['Content-Type'] = 'application/x-www-form-urlencoded;charset=UTF-8';
+			options.body = elasticsearch_settings.encodeData(data);
+		}
+
+		return fetch(window.OC.generateUrl(route), options).then(function (response) {
+			if (!response.ok) {
+				throw new Error('Request failed: ' + response.status);
+			}
+
+			return response.json();
+		});
+	},
+
+
+	encodeData: function (data) {
+		var params = new URLSearchParams();
+		Object.keys(data).forEach(function (key) {
+			params.append('data[' + key + ']', data[key]);
+		});
+
+		return params.toString();
 	}
 
 


### PR DESCRIPTION
Fixes nextcloud/fulltextsearch_elasticsearch#472 by replacing the Elasticsearch admin settings page's global jQuery dependency with vanilla JavaScript. Host, index, and analyzer tokenizer settings now load and save on Nextcloud 34. Also raises the app compatibility max-version to Nextcloud 34.

Related PRs: [fulltextsearch](https://github.com/nextcloud/fulltextsearch/pull/952) and [files_fulltextsearch](https://github.com/nextcloud/files_fulltextsearch/pull/365) admin UI fixes should land together.

### Related Links
- https://github.com/nextcloud/fulltextsearch/pull/952
- https://github.com/nextcloud/files_fulltextsearch/pull/365

## Verification

Tested this change end-to-end on a clean stack:

- **Nextcloud** 34.0.0
- **Elasticsearch** 9.4.2 (with the `ingest-attachment` plugin)
- App built from this branch, search platform set to Elasticsearch

### Admin UI (the actual fix)
- `/settings/admin/fulltextsearch` loads with **no `ReferenceError: $ is not defined`** and no CSP errors in the browser console.
- The Elasticsearch settings fields (host, index, advanced options) **populate with the current values** on load.
- Editing the host/index and saving **persists** the values; after a full page reload they are still correct.

### Backend confirmation via `occ`

`occ fulltextsearch:check` — platform is Selected with the expected host/index:

```
- Search Platform:
Elasticsearch 32.0.0 (Selected)
{
    "elastic_host": [ "http://elasticsearch:9200" ],
    "elastic_index": "nextcloud",
    "analyzer_tokenizer": "standard",
    "allow_self_signed_cert": false
}
```

`occ fulltextsearch:test` - passes end-to-end:

```
Loading search platform. (Elasticsearch) ok
Testing search platform. ok
Initializing index mapping. ok
Indexing generated documents. ok
Retreiving content from a big index (license). (size: 32386) ok
Comparing document with source. ok
Searching basic keywords:           ... all ok
Searching with group access rights: ... all ok
Searching with share rights:        ... all ok
Removing test. ok
Unlocking process ok
```

So the platform/indexing logic is untouched and healthy - this PR only restores the admin UI on NC 34 by removing the dependency on the removed global jQuery.

Cross-refs: nextcloud/fulltextsearch#952 · nextcloud/files_fulltextsearch#365 (these three should land together; `fulltextsearch` is the base).

<img width="1578" height="1341" alt="Screenshot 2026-06-25 at 13 55 28" src="https://github.com/user-attachments/assets/fc02780d-1700-4e03-a81a-ec3799b81ec9" />

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
