### PR TITLE
fix broken self signed cert support

### DIFF
--- a/lib/Platform/ElasticSearchPlatform.php
+++ b/lib/Platform/ElasticSearchPlatform.php
@@ -389,25 +389,28 @@ class ElasticSearchPlatform implements IFullTextSearchPlatform {
 	 */
 	private function connectToElastic(array $hosts): void {
 		$hosts = array_map([$this, 'cleanHost'], $hosts);
-        if ($this->downgradingES) {
-            $cb = ClientBuilder8::create();
-        } else {
-            $cb = ClientBuilder::create();
-        }
+		if ($this->downgradingES) {
+			$cb = ClientBuilder8::create();
+		} else {
+			$cb = ClientBuilder::create();
+		}
 
-        $cb->setHosts($hosts)
-            ->setRetries(3);
+		$cb->setHosts($hosts)
+			->setRetries(3);
 
-        if ($this->appConfig->getAppValueBool(ConfigLexicon::ELASTIC_LOGGER_ENABLED)) {
+		if ($this->appConfig->getAppValueBool(ConfigLexicon::ELASTIC_LOGGER_ENABLED)) {
 			$cb->setLogger($this->logger);
 		}
 
-		$cb->setSSLVerification(!$this->appConfig->getAppValueBool(ConfigLexicon::ALLOW_SELF_SIGNED_CERT));
-        $cb->setCABundle($this->certificateManager->getAbsoluteBundlePath());
+		$allowSelfSignedCert = $this->appConfig->getAppValueBool(ConfigLexicon::ALLOW_SELF_SIGNED_CERT);
+		$cb->setSSLVerification(!$allowSelfSignedCert);
+		if (!$allowSelfSignedCert) {
+			$cb->setCABundle($this->certificateManager->getAbsoluteBundlePath());
+		}
 		$this->configureAuthentication($cb, $hosts);
 
 		$this->client = $cb->build();
-        $this->confirmESVersion();
+		$this->confirmESVersion();
 	}
 
     /**


### PR DESCRIPTION
calling ClientBuilder::setCABundle seems to have enforced certificate verification as a side effect, breaking support for allowing self signed certificates. When allowing self signed certificates the CA bundle is meaningless anyway, so a simple fix is to only call setCABundle when self signed certificates are not allowed.

Example without this fix:
```
www-data@nextcloud-dev-5c5998db9f-hn5t5:~$ html/occ fulltextsearch:configure           
{
    "app_navigation": false,
    "search_platform": "OCA\\FullTextSearch_Elasticsearch\\Platform\\ElasticSearchPlatform",
    "collection_internal": "local",
    "cron_err_reset": 0,
    "tick_ttl": 1800,
    "collection_indexing_list": 50,
    "collection_links": []
}
www-data@nextcloud-dev-5c5998db9f-hn5t5:~$ html/occ fulltextsearch_elasticsearch:configure
{
    "fields_limit": 10000,
    "elastic_host": "https:\/\/elastic:***@nextcloud-es-http:9200\/",
    "elastic_index": "nc_fts",
    "elastic_logger_enabled": false,
    "analyzer_tokenizer": "standard",
    "allow_self_signed_cert": true
}
www-data@nextcloud-dev-5c5998db9f-hn5t5:~$ html/occ fulltextsearch:index -r

In CurlFactory.php line 838:
                                                                                                                                                                         
  cURL error 60: SSL certificate problem: self-signed certificate in certificate chain (see https://curl.se/libcurl/c/libcurl-errors.html) for https://elastic:***@next  
  cloud-es-http:9200/                                                                                                                                                    
                                                                                                                                                                         

fulltextsearch:index [--output [OUTPUT]] [-r|--no-readline] [--] [<options>]

www-data@nextcloud-dev-5c5998db9f-hn5t5:~$
```